### PR TITLE
Add Harmony integration and multiple AI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # RimGPT
 
-RimGPT is a proof-of-concept RimWorld mod that uses the OpenAI API to generate
-backstories, biographies and pawn conversations with ChatGPT.
+RimGPT is a proof-of-concept RimWorld mod that uses various AI APIs to
+generate backstories, biographies and pawn conversations. The mod now patches
+the game using Harmony so the biographies are generated as pawns spawn.
 
 ## Structure
 
@@ -14,9 +15,13 @@ backstories, biographies and pawn conversations with ChatGPT.
 2. Run `dotnet build` inside the `Source/RimGPT` directory.
 3. Copy `bin/Debug/net48/RimGPT.dll` to `RimGPTMod/Assemblies`.
 
-Set your OpenAI API key in the environment variable `OPENAI_API_KEY` before
-launching RimWorld.
+Set your API keys before launching RimWorld:
 
-This is only a minimal example for educational purposes. It demonstrates how to
-call ChatGPT from RimWorld but does not integrate fully with the game's UI or
-pawn dialogue system.
+- `OPENAI_API_KEY` for the OpenAI API.
+- `GEMINI_API_KEY` for the Gemini API.
+- `OPENROUTER_API_KEY` for the OpenRouter API.
+
+You can choose which provider to use in the mod settings.
+
+This is still a minimal example for educational purposes, but it now integrates
+with RimWorld through Harmony patches and supports multiple AI providers.

--- a/RimGPTMod/About/About.xml
+++ b/RimGPTMod/About/About.xml
@@ -5,5 +5,5 @@
   <supportedVersions>
     <li>1.4</li>
   </supportedVersions>
-  <description>A mod that uses ChatGPT to generate backstories, biographies, and conversations between pawns.</description>
+  <description>A mod that uses various AI APIs to generate backstories, biographies and conversations between pawns. It integrates with RimWorld using Harmony patches.</description>
 </ModMetaData>

--- a/Source/RimGPT/ApiProvider.cs
+++ b/Source/RimGPT/ApiProvider.cs
@@ -1,0 +1,9 @@
+namespace RimGPT
+{
+    public enum ApiProvider
+    {
+        OpenAI,
+        Gemini,
+        OpenRouter
+    }
+}

--- a/Source/RimGPT/IAIClient.cs
+++ b/Source/RimGPT/IAIClient.cs
@@ -1,0 +1,7 @@
+namespace RimGPT
+{
+    public interface IAIClient
+    {
+        System.Threading.Tasks.Task<string?> GenerateAsync(string prompt);
+    }
+}

--- a/Source/RimGPT/OpenRouterClient.cs
+++ b/Source/RimGPT/OpenRouterClient.cs
@@ -6,26 +6,26 @@ using Newtonsoft.Json;
 
 namespace RimGPT
 {
-    public class OpenAIClient : IAIClient
+    public class OpenRouterClient : IAIClient
     {
         private readonly HttpClient _client = new HttpClient();
         private readonly string? _apiKey;
 
-        public OpenAIClient(string? apiKey = null)
+        public OpenRouterClient(string? apiKey = null)
         {
-            _apiKey = apiKey ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+            _apiKey = apiKey ?? Environment.GetEnvironmentVariable("OPENROUTER_API_KEY");
         }
 
         public async Task<string?> GenerateAsync(string prompt)
         {
             if (string.IsNullOrEmpty(_apiKey))
             {
-                throw new InvalidOperationException("OpenAI API key not set. Set OPENAI_API_KEY environment variable or pass in an apiKey.");
+                throw new InvalidOperationException("OpenRouter API key not set. Set OPENROUTER_API_KEY environment variable or pass in an apiKey.");
             }
 
             var requestBody = new
             {
-                model = "gpt-3.5-turbo",
+                model = "openrouter/gpt-3.5-turbo",
                 messages = new[]
                 {
                     new { role = "user", content = prompt }
@@ -35,8 +35,7 @@ namespace RimGPT
             var content = new StringContent(JsonConvert.SerializeObject(requestBody), Encoding.UTF8, "application/json");
             _client.DefaultRequestHeaders.Clear();
             _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_apiKey}");
-
-            var response = await _client.PostAsync("https://api.openai.com/v1/chat/completions", content);
+            var response = await _client.PostAsync("https://openrouter.ai/api/v1/chat/completions", content);
             response.EnsureSuccessStatusCode();
             var json = await response.Content.ReadAsStringAsync();
             dynamic? data = JsonConvert.DeserializeObject(json);

--- a/Source/RimGPT/RimGPT.csproj
+++ b/Source/RimGPT/RimGPT.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="0Harmony" Version="2.2.2" />
   </ItemGroup>
 </Project>

--- a/Source/RimGPT/RimGPTMod.cs
+++ b/Source/RimGPT/RimGPTMod.cs
@@ -1,17 +1,59 @@
-using Verse;
+using HarmonyLib;
 using RimWorld;
 using System.Threading.Tasks;
+using Verse;
 
 namespace RimGPT
 {
     public class RimGPTMod : Mod
     {
+        public static RimGPTSettings Settings { get; private set; } = new RimGPTSettings();
+        public static IAIClient Client { get; private set; } = new OpenAIClient();
+        private readonly Harmony _harmony;
+
         public RimGPTMod(ModContentPack content) : base(content)
         {
-            Log.Message("RimGPT loaded");
+            Settings = GetSettings<RimGPTSettings>();
+            InitializeClient();
+            _harmony = new Harmony("rimworld.rimgpt.mod");
+            _harmony.PatchAll();
+            Log.Message("RimGPT loaded with " + Settings.Provider + " provider");
         }
 
         public override string SettingsCategory() => "RimGPT";
+
+        public override void DoSettingsWindowContents(UnityEngine.Rect inRect)
+        {
+            Listing_Standard list = new Listing_Standard();
+            list.Begin(inRect);
+            list.Label("AI Provider:");
+            foreach (ApiProvider provider in System.Enum.GetValues(typeof(ApiProvider)))
+            {
+                if (list.RadioButton(provider.ToString(), Settings.Provider == provider))
+                {
+                    Settings.Provider = provider;
+                    InitializeClient();
+                }
+            }
+            list.End();
+            Settings.Write();
+        }
+
+        private static void InitializeClient()
+        {
+            switch (Settings.Provider)
+            {
+                case ApiProvider.Gemini:
+                    Client = new GeminiClient();
+                    break;
+                case ApiProvider.OpenRouter:
+                    Client = new OpenRouterClient();
+                    break;
+                default:
+                    Client = new OpenAIClient();
+                    break;
+            }
+        }
     }
 
     [StaticConstructorOnStartup]
@@ -19,15 +61,14 @@ namespace RimGPT
     {
         static RimGPTInitializer()
         {
-            _ = InitializeAsync();
+            _ = SampleAsync();
         }
 
-        private static async Task InitializeAsync()
+        private static async Task SampleAsync()
         {
-            var client = new OpenAIClient();
             try
             {
-                string? result = await client.GenerateAsync("Generate a short biography for a RimWorld colonist.");
+                string? result = await RimGPTMod.Client.GenerateAsync("Generate a short biography for a RimWorld colonist.");
                 if (!string.IsNullOrEmpty(result))
                 {
                     Log.Message($"RimGPT sample response: {result}");
@@ -35,7 +76,33 @@ namespace RimGPT
             }
             catch (System.Exception ex)
             {
-                Log.Error($"RimGPT failed to contact OpenAI: {ex}");
+                Log.Error($"RimGPT failed to contact API: {ex}");
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(PawnGenerator), "GeneratePawn")]
+    public static class PawnGeneratorPatch
+    {
+        public static void Postfix(Pawn __result)
+        {
+            if (__result == null) return;
+            _ = ApplyBiographyAsync(__result);
+        }
+
+        private static async Task ApplyBiographyAsync(Pawn pawn)
+        {
+            try
+            {
+                string? bio = await RimGPTMod.Client.GenerateAsync($"Generate a short biography for a RimWorld colonist named {pawn.LabelShort}. Include details about their past.");
+                if (!string.IsNullOrEmpty(bio))
+                {
+                    Messages.Message($"Biography for {pawn.LabelShort}:\n{bio}", MessageTypeDefOf.NeutralEvent, false);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Log.Error($"RimGPT biography generation failed: {ex}");
             }
         }
     }

--- a/Source/RimGPT/RimGPTSettings.cs
+++ b/Source/RimGPT/RimGPTSettings.cs
@@ -1,0 +1,14 @@
+using Verse;
+
+namespace RimGPT
+{
+    public class RimGPTSettings : ModSettings
+    {
+        public ApiProvider Provider = ApiProvider.OpenAI;
+
+        public override void ExposeData()
+        {
+            Scribe_Values.Look(ref Provider, "provider", ApiProvider.OpenAI);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate with RimWorld using Harmony
- add AI provider selection and settings
- support Gemini and OpenRouter APIs alongside OpenAI
- document new providers and environment variables
- update mod description

## Testing
- `dotnet build Source/RimGPT/RimGPT.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc35ba288328a33c683a36a270b1